### PR TITLE
Fix Windows build problems in AARLibrary

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/util/AARLibrary.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/util/AARLibrary.java
@@ -122,8 +122,8 @@ public class AARLibrary {
    */
   public AARLibrary(final File aar) {
     aarPath = aar;
-    String temp = aar.getAbsolutePath();
-    name = temp.substring(temp.lastIndexOf('/'), temp.length()-4);
+    String temp = aar.getName();
+    name = temp.substring(0, temp.length()-4);
   }
 
   public File getFile() {


### PR DESCRIPTION
A hard-coded '/' breaks builds involving Maps on Windows. This commit
switches to using File.getName() to get the name of archive before
stripping its '.aar' file extension.

Change-Id: I2b43569011975ef1d1ee33f28fbc4d1270e5f331